### PR TITLE
fix: ignore onnxruntime-gpu for macOS and for arm64 CPUs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 facexlib
 insightface
 onnxruntime
-onnxruntime-gpu
+onnxruntime-gpu; sys_platform != 'darwin' and platform_machine == 'x86_64'
 ftfy
 timm


### PR DESCRIPTION
The description of this change is here: https://github.com/cubiq/PuLID_ComfyUI/pull/72

_Thank you for deciding to support the PuLID node for Flux_