### PR TITLE
Fix OUTER_SAMPLE wrappers for ComfyUI latent_shapes

### DIFF
--- a/pulidflux.py
+++ b/pulidflux.py
@@ -618,7 +618,7 @@ def pulid_outer_sample_wrappers_with_override(wrapper_executor, noise, latent_im
     cfg_guider = wrapper_executor.class_obj
     PULID_model_patch = add_model_patch_option(cfg_guider, PatchKeys.pulid_patch_key_attrs)
     PULID_model_patch['latent_image_shape'] = latent_image.shape
-    
+
     diffusion_model = cfg_guider.model_patcher.model.diffusion_model
     set_hook(diffusion_model, pulid_forward_orig)
     try:

--- a/pulidflux.py
+++ b/pulidflux.py
@@ -614,15 +614,19 @@ def clean_hook(diffusion_model):
         diffusion_model.forward_orig = diffusion_model.old_forward_orig_for_pulid
         del diffusion_model.old_forward_orig_for_pulid
 
-def pulid_outer_sample_wrappers_with_override(wrapper_executor, noise, latent_image, sampler, sigmas, denoise_mask=None, callback=None, disable_pbar=False, seed=None, **kwargs):
+def pulid_outer_sample_wrappers_with_override(wrapper_executor, noise, latent_image, sampler, sigmas, denoise_mask=None, callback=None, disable_pbar=False, seed=None, latent_shapes=None, **kwargs):
     cfg_guider = wrapper_executor.class_obj
     PULID_model_patch = add_model_patch_option(cfg_guider, PatchKeys.pulid_patch_key_attrs)
     PULID_model_patch['latent_image_shape'] = latent_image.shape
-
+    
     diffusion_model = cfg_guider.model_patcher.model.diffusion_model
     set_hook(diffusion_model, pulid_forward_orig)
-    try :
-        out = wrapper_executor(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, **kwargs)
+    try:
+        # Backwards compatiblity: only pass latent_shapes when ComfyUI provides it
+        if latent_shapes is None:
+            out = wrapper_executor(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, **kwargs)
+        else:
+            out = wrapper_executor(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes=latent_shapes, **kwargs)
     finally:
         del PULID_model_patch['latent_image_shape']
         clean_hook(diffusion_model)
@@ -630,12 +634,16 @@ def pulid_outer_sample_wrappers_with_override(wrapper_executor, noise, latent_im
 
     return out
 
-def pulid_outer_sample_wrappers(wrapper_executor, noise, latent_image, sampler, sigmas, denoise_mask=None, callback=None, disable_pbar=False, seed=None, **kwargs):
+
+def pulid_outer_sample_wrappers(wrapper_executor, noise, latent_image, sampler, sigmas, denoise_mask=None, callback=None, disable_pbar=False, seed=None, latent_shapes=None, **kwargs):
     cfg_guider = wrapper_executor.class_obj
     PULID_model_patch = add_model_patch_option(cfg_guider, PatchKeys.pulid_patch_key_attrs)
     PULID_model_patch['latent_image_shape'] = latent_image.shape
     try:
-        out = wrapper_executor(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, **kwargs)
+        if latent_shapes is None:
+            out = wrapper_executor(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, **kwargs)
+        else:
+            out = wrapper_executor(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes=latent_shapes, **kwargs)
     finally:
         del PULID_model_patch['latent_image_shape']
 


### PR DESCRIPTION
ComfyUI now passes `latent_shapes` through OUTER_SAMPLE wrappers, which causes:
`TypeError: pulid_outer_sample_wrappers_with_override() got an unexpected keyword argument 'latent_shapes'`

This PR updates:
- `pulid_outer_sample_wrappers_with_override`
- `pulid_outer_sample_wrappers`

to accept `latent_shapes=None, **kwargs` and forward `latent_shapes` only when provided (backwards compatible with older ComfyUI versions).

Fixes #88